### PR TITLE
Fixed Mutex Errors

### DIFF
--- a/Officer.cs
+++ b/Officer.cs
@@ -9,7 +9,7 @@ namespace Officer_Project
 {
     class Officer
     {
-        private Mutex _mutex = new Mutex();
+        // private Mutex _mutex = new Mutex();
         private int _currentCustomerTimeInside;
         public int Timer { get; set; }
         private int _customersServed = 0;
@@ -21,24 +21,39 @@ namespace Officer_Project
 
         public void CallNextOne(Object i)
         {
-            while (QueueManagement.Customers > 0)
+            // Attempt to use QueueManagement's static Mutex instance.
+            // int customers = -1;   // Attempt to use local variable as checking storage.
+
+            // Replace with do/while for checking after reassignment
+            do
             {
-                _mutex.WaitOne();
-                if (QueueManagement.Customers > 0)
+                if (QueueManagement._mutex.WaitOne())  // This if makes sure the code is executed only when the Mutex is acquired by the Officer instance
                 {
-                    QueueManagement.Customers--;
-                    _mutex.ReleaseMutex();
-                    _currentCustomerTimeInside = QueueManagement._random.Next(QueueManagement._timeInside - 5, QueueManagement._timeInside + 5);
-                    Thread.Sleep(_currentCustomerTimeInside);
-                    Timer += _currentCustomerTimeInside;
-                    _customersServed++;
+                   // customers = QueueManagement.Customers;
+
+                    // DEBUG LINE: Console.WriteLine(String.Format("Mutex in QueueManagement acquired by Officer {0}, current customer count is {1}", (int)i + 1, customers));
+
+                    if (QueueManagement.Customers > 0)
+                    {
+                        QueueManagement.Customers--;
+                        QueueManagement._mutex.ReleaseMutex();
+                        _currentCustomerTimeInside = QueueManagement._random.Next(QueueManagement._timeInside - 5, QueueManagement._timeInside + 5);
+                        Thread.Sleep(_currentCustomerTimeInside);
+                        Timer += _currentCustomerTimeInside;
+                        _customersServed++;
+                    }
+                    else
+                    {
+                        QueueManagement._mutex.ReleaseMutex();
+                        break;
+                    }
                 }
-                else
-                {
-                    _mutex.ReleaseMutex();
-                    break;
-                }
-            }
+                // DEBUG ELSE PATH
+                // else
+                // {
+                //     Console.WriteLine(String.Format("Mutex in QueueManagement not acquired by Officer {0}", (int)i + 1));
+                // }
+            } while (QueueManagement.Customers > 0);
             Console.WriteLine("Officer {0} Done!, worked {1} minutes, served {2}, {3} are now in the line",(int) i + 1, Timer, _customersServed, QueueManagement.Customers);
         }
     }

--- a/Program.cs
+++ b/Program.cs
@@ -47,6 +47,9 @@ namespace Officer_Project
                 threads[i] = new Thread(new ParameterizedThreadStart(theOffice[i].CallNextOne));
                 threads[i].Start(i);
             }
+
+            // Console.WriteLine("PRESS A KEY TO EXIT");  // Pauses program exit.
+            // Console.ReadKey();                         // Pauses program exit.
         }
     }
 }

--- a/QueueManagement.cs
+++ b/QueueManagement.cs
@@ -7,6 +7,11 @@ using System.Threading.Tasks;
 
 namespace Officer_Project
 {
+    // Consider using a struct with public non-static members with { get; private set; } accessors
+    // (or { get; set; }) in the case of _customers.
+    // instead for holding values without much methods.
+    // Assignments and modifications to fields are faster than if using class.
+    // See: https://www.c-sharpcorner.com/blogs/difference-between-struct-and-class-in-c-sharp
     class QueueManagement
     {
         private static int _customers;
@@ -23,7 +28,11 @@ namespace Officer_Project
                 //_mutex.ReleaseMutex();
             }
         }
-        private static Mutex _mutex = new Mutex();
+
+        // Changed access level to public so Officer instances can access.
+        // Added readonly so that Officer instances cannot replace this with a new instance.
+        public static readonly Mutex _mutex = new Mutex();  // Using this instead of an individial Mutex in each Officer
+
         public static int _timeInside;
         private int _officers;
         public static Random _random = new Random();


### PR DESCRIPTION
Fixed total customer count at the end not matching input amount.
See Officer.cs and QueueManagement.cs for comments and information.

Summary: Changed Mutex to use the static instance in the resource (i.e. QueueManagment) and added if check to Officer.cs to only execute operation if Mutex is acquired by the thread.